### PR TITLE
support for deployment circuit breakers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,12 @@ resource "aws_ecs_service" "service" {
     # The deployment controller type to use. Valid values: CODE_DEPLOY, ECS.
     type = var.deployment_controller_type
   }
+
+  deployment_circuit_breaker {
+    enable   = var.circuit_breaker_enable
+    rollback = var.circuit_breaker_rollback
+  }
+
 }
 
 # HACK: The workaround used in ecs/service does not work for some reason in this module, this fixes the following error:

--- a/variables.tf
+++ b/variables.tf
@@ -171,3 +171,15 @@ variable "repository_credentials_kms_key" {
   type        = string
 }
 
+variable "circuit_breaker_enable" {
+  type        = bool
+  description = "whether or not to enable the deployment circuit breaker. This prevents re-deployment cycles on failing health checks for example"
+  default     = false
+}
+
+variable "circuit_breaker_rollback" {
+  type        = bool
+  description = "whether or not to enable the deployment circuit breaker to roll back to a previous task definition if deployment fails"
+  default     = false
+
+}


### PR DESCRIPTION
I have added optional support for deployment circuit breakers, default turned off so that the module is "backwards compatible"