### PR TITLE
Add an optional health check to the container definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,7 @@ locals {
     }
     "privileged" : var.privileged
     "readonlyRootFilesystem" : var.readonlyRootFilesystem
+    "healthCheck" : var.container_health_check
   }, local.task_container_secrets, local.repository_credentials)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -314,3 +314,17 @@ variable "extra_target_groups" {
   }))
   default = []
 }
+
+variable "container_health_check" {
+  description = "An ECS TaskDefinition HealthCheck object to set in each container"
+  default     = null
+  type = object(
+    {
+      command     = list(string)
+      interval    = number
+      retries     = number
+      startPeriod = number
+      timeout     = number
+    }
+  )
+}


### PR DESCRIPTION
This update enables passing a health check object to the container so that ECS can evaluate the task health - very useful if you are not using an ALB / target groups