### PR TITLE
Remove target group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,6 @@ resource "aws_security_group_rule" "egress_service" {
 # LB Target group
 # ------------------------------------------------------------------------------
 resource "aws_lb_target_group" "task" {
-  name        = "${var.name_prefix}-${var.task_container_port}"
   count       = var.lb_arn == "" ? 0 : 1
   vpc_id      = var.vpc_id
   protocol    = var.task_container_protocol


### PR DESCRIPTION
The target group name was added for readability but was orignially excluded because of problems destroying a target group while a listener was attached. See comment in code. This was removed again in case this was still an issue and becuase of a length limit of 32 chars for the name parameter which was causing problems